### PR TITLE
When you're not the author you could avoid having Edit and Delete links

### DIFF
--- a/sk/src/routes/posts/+page.svelte
+++ b/sk/src/routes/posts/+page.svelte
@@ -18,6 +18,7 @@
 <table>
   <tbody>
     {#each $posts.items as post}
+       {#if $currentUser.id == post.user}
       <tr>
         <td>
           <Image
@@ -32,6 +33,20 @@
         <td><a href={`${post.id}/edit`}>Edit</a></td>
         <td><a href={`${post.slug}#delete`}>Delete</a></td>
       </tr>
+      {:else}
+      <tr>
+        <td>
+          <Image
+            record={post}
+            file={post.files[0]}
+            thumb="100x100"
+            alt={post.title}
+          />
+        </td>
+        <td><a href={post.slug}>{post.title}</a></td>
+        <td>{post.updated}</td>
+      </tr>
+      {/if}
     {:else}
       <tr>
         <td>No posts found.</td>


### PR DESCRIPTION
When you're not the author of a post you can't edit and delete and you get a (too) broad error message: `The requested resource wasn't found`

If you test for each record using `$currentUser.id == post.user`, you can remove edit and delete links :)
Hope it helps others understand about the SK logic.

I'm learning about Pocketbase, maybe there's a clever way.